### PR TITLE
제보된 플레이어 참가시 경고 추가 등

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea/
 /build/
 /test/
+.DS_Store

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/src/main/java/space/ourmc/userdb/bukkit/OmsUserDbBukkit.java
+++ b/src/main/java/space/ourmc/userdb/bukkit/OmsUserDbBukkit.java
@@ -2,12 +2,14 @@ package space.ourmc.userdb.bukkit;
 
 import org.bukkit.plugin.java.JavaPlugin;
 import space.ourmc.userdb.bukkit.command.OmsUserDbCommand;
+import space.ourmc.userdb.bukkit.event.OmsUserDbListener;
 
 public final class OmsUserDbBukkit extends JavaPlugin  {
 
     @Override
     public void onEnable() {
         getCommand("userdb").setExecutor(new OmsUserDbCommand(this));
+        getServer().getPluginManager().registerEvents(new OmsUserDbListener(this), this);
         if (getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
             ReportUrlAlerter.register(this);
         }

--- a/src/main/java/space/ourmc/userdb/bukkit/OmsUserDbBukkit.java
+++ b/src/main/java/space/ourmc/userdb/bukkit/OmsUserDbBukkit.java
@@ -8,6 +8,7 @@ public final class OmsUserDbBukkit extends JavaPlugin  {
 
     @Override
     public void onEnable() {
+        saveDefaultConfig();
         getCommand("userdb").setExecutor(new OmsUserDbCommand(this));
         getServer().getPluginManager().registerEvents(new OmsUserDbListener(this), this);
         if (getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {

--- a/src/main/java/space/ourmc/userdb/bukkit/OmsUserDbBukkit.java
+++ b/src/main/java/space/ourmc/userdb/bukkit/OmsUserDbBukkit.java
@@ -2,7 +2,7 @@ package space.ourmc.userdb.bukkit;
 
 import org.bukkit.plugin.java.JavaPlugin;
 import space.ourmc.userdb.bukkit.command.OmsUserDbCommand;
-import space.ourmc.userdb.bukkit.event.OmsUserDbListener;
+import space.ourmc.userdb.bukkit.listener.OmsUserDbListener;
 
 public final class OmsUserDbBukkit extends JavaPlugin  {
 

--- a/src/main/java/space/ourmc/userdb/bukkit/ReportUrlAlerter.java
+++ b/src/main/java/space/ourmc/userdb/bukkit/ReportUrlAlerter.java
@@ -29,6 +29,7 @@ public final class ReportUrlAlerter {
             public void onPacketSending(PacketEvent event) {
                 PacketContainer packet = event.getPacket();
                 WrappedChatComponent chat = packet.getChatComponents().read(0);
+                if(chat == null) return;
                 JsonElement json = new JsonParser().parse(chat.getJson());
                 if (!json.isJsonObject()) return;
                 JsonObject object = (JsonObject) json;

--- a/src/main/java/space/ourmc/userdb/bukkit/command/OmsUserDbCommand.java
+++ b/src/main/java/space/ourmc/userdb/bukkit/command/OmsUserDbCommand.java
@@ -33,6 +33,11 @@ public final class OmsUserDbCommand implements CommandExecutor  {
             sender.sendMessage("Usage: /" + label + " [search <username>/get <UUID/username>]");
             return true;
         }
+        if(args[0].equalsIgnoreCase("reload")) {
+            sender.sendMessage(ChatColor.GREEN + "Reloading config...");
+            plugin.reloadConfig();
+            return true;
+        }
         if (args[0].equalsIgnoreCase("search")) {
             return search(sender, command, label, args);
         }

--- a/src/main/java/space/ourmc/userdb/bukkit/event/OmsUserDbListener.java
+++ b/src/main/java/space/ourmc/userdb/bukkit/event/OmsUserDbListener.java
@@ -25,7 +25,10 @@ public class OmsUserDbListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        List<Player> receivers = player.getServer().getOnlinePlayers().stream().filter(ServerOperator::isOp).collect(Collectors.toList());
+
+        if(player.hasPermission("userdb.report.bypass")) return;
+
+        List<Player> receivers = player.getServer().getOnlinePlayers().stream().filter(p -> p.hasPermission("userdb.report.receive")).collect(Collectors.toList());
         try {
             OmsUserDb.getReportCountOfUser(player.getUniqueId()).thenAccept(result -> plugin.getServer().getScheduler().runTask(plugin, () -> {
                 if (result.count == 0) {

--- a/src/main/java/space/ourmc/userdb/bukkit/event/OmsUserDbListener.java
+++ b/src/main/java/space/ourmc/userdb/bukkit/event/OmsUserDbListener.java
@@ -1,0 +1,59 @@
+package space.ourmc.userdb.bukkit.event;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.permissions.ServerOperator;
+import org.bukkit.plugin.Plugin;
+import space.ourmc.userdb.api.OmsUserDb;
+import space.ourmc.userdb.api.OmsUserDbException;
+
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
+
+public class OmsUserDbListener implements Listener {
+
+    public final Plugin plugin;
+
+    public OmsUserDbListener(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        List<Player> receivers = player.getServer().getOnlinePlayers().stream().filter(ServerOperator::isOp).collect(Collectors.toList());
+        try {
+            OmsUserDb.getReportCountOfUser(player.getUniqueId()).thenAccept(result -> plugin.getServer().getScheduler().runTask(plugin, () -> {
+                if (result.count == 0) {
+                    receivers.forEach(receiver -> {
+                        receiver.sendMessage(ChatColor.GREEN + "No reports found for " + ChatColor.YELLOW + player.getName());
+                    });
+                    return;
+                }
+                receivers.forEach(receiver -> {
+                    receiver.sendMessage(result.count + " report(s) found for " + ChatColor.YELLOW + player.getName());
+                    receiver.sendMessage("Use " + ChatColor.AQUA + "/userdb get " + player.getName() + " for more details");
+                });
+            })).exceptionally(throwable -> {
+                if (throwable instanceof CompletionException && throwable.getCause() instanceof OmsUserDbException) {
+                    OmsUserDbException e = (OmsUserDbException) throwable.getCause();
+                    if (e.code == 404) {
+                        plugin.getServer().getScheduler().runTask(plugin, () -> {
+                            receivers.forEach(receiver -> {
+                                receiver.sendMessage(ChatColor.GREEN + "No reports found for " + ChatColor.YELLOW + player.getName());
+                            });
+                        });
+                    }
+                }
+                return null;
+            });
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/space/ourmc/userdb/bukkit/event/ReportedPlayerJoinEvent.java
+++ b/src/main/java/space/ourmc/userdb/bukkit/event/ReportedPlayerJoinEvent.java
@@ -22,4 +22,8 @@ public class ReportedPlayerJoinEvent extends PlayerEvent {
     public HandlerList getHandlers() {
         return handlers;
     }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 }

--- a/src/main/java/space/ourmc/userdb/bukkit/event/ReportedPlayerJoinEvent.java
+++ b/src/main/java/space/ourmc/userdb/bukkit/event/ReportedPlayerJoinEvent.java
@@ -1,0 +1,25 @@
+package space.ourmc.userdb.bukkit.event;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+
+public class ReportedPlayerJoinEvent extends PlayerEvent {
+    private static final HandlerList handlers = new HandlerList();
+
+    private final int reportCount;
+
+    public ReportedPlayerJoinEvent(Player playerJoined, int reportCount) {
+        super(playerJoined);
+        this.reportCount = reportCount;
+    }
+
+    public int getReportCount() {
+        return reportCount;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+}

--- a/src/main/java/space/ourmc/userdb/bukkit/listener/OmsUserDbListener.java
+++ b/src/main/java/space/ourmc/userdb/bukkit/listener/OmsUserDbListener.java
@@ -1,14 +1,15 @@
-package space.ourmc.userdb.bukkit.event;
+package space.ourmc.userdb.bukkit.listener;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.permissions.ServerOperator;
 import org.bukkit.plugin.Plugin;
 import space.ourmc.userdb.api.OmsUserDb;
 import space.ourmc.userdb.api.OmsUserDbException;
+import space.ourmc.userdb.bukkit.event.ReportedPlayerJoinEvent;
 
 import java.util.List;
 import java.util.concurrent.CompletionException;
@@ -25,7 +26,6 @@ public class OmsUserDbListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-
         if(player.hasPermission("userdb.report.bypass")) return;
 
         List<Player> receivers = player.getServer().getOnlinePlayers().stream().filter(p -> p.hasPermission("userdb.report.receive")).collect(Collectors.toList());
@@ -40,6 +40,7 @@ public class OmsUserDbListener implements Listener {
                 receivers.forEach(receiver -> {
                     receiver.sendMessage(result.count + " report(s) found for " + ChatColor.YELLOW + player.getName());
                     receiver.sendMessage("Use " + ChatColor.AQUA + "/userdb get " + player.getName() + " for more details");
+                    Bukkit.getPluginManager().callEvent(new ReportedPlayerJoinEvent(player, result.count));
                 });
             })).exceptionally(throwable -> {
                 if (throwable instanceof CompletionException && throwable.getCause() instanceof OmsUserDbException) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,3 @@
+alert:
+  enable: true
+  send-event: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,8 +9,14 @@ commands:
   userdb:
     description: Search OMS UserDb
     usage: /userdb [search <username>/get <UUID/username>]
-    permission: userdb
+    permission: userdb.command
 permissions:
-  userdb:
+  userdb.command:
     description: userdb command
     default: op
+  userdb.alert.receive:
+    description: receive alert when a reported user joins
+    default: op
+  userdb.alert.bypass:
+    description: bypass being alerted
+    default: false


### PR DESCRIPTION
변경 사항은 다음과 같습니다.

* 플레이어 참여시 DB를 조회하여 그 결과를 온라인 상태인 관리자에게 보고하는 기능 추가
* 타 플러그인 연동을 위해 DB 조회 결과가 있을 경우 서버 이벤트를 발생시킴
* 경고 관련 노드 추가에 따라 커맨드 사용을 위해 필요한 퍼미션 노드를 변경
* ReportUrlAlerter에서 NPE가 수시로 발생하는 버그 수정

제보 이력이 있는 유저를 서버에 참가시켜 볼 방법이 없는 관계로 만든 기능을 모두 테스트해보진 못했습니다만, 최소한 작동은 할 거라 생각됩니다.